### PR TITLE
feat: JwtHeaderFilter 구현

### DIFF
--- a/src/main/java/com/fhsh/gatewayserver/filter/JwtHeaderFilter.java
+++ b/src/main/java/com/fhsh/gatewayserver/filter/JwtHeaderFilter.java
@@ -1,0 +1,49 @@
+package com.fhsh.gatewayserver.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+public class JwtHeaderFilter implements GlobalFilter {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+
+        return exchange.getPrincipal()
+                .cast(Authentication.class)
+                .flatMap(auth -> {
+
+                    // JWT 아닌 경우 그냥 통과
+                    if (!(auth instanceof JwtAuthenticationToken jwtAuth)) {
+                        return chain.filter(exchange);
+                    }
+
+                    var jwt = jwtAuth.getToken();
+
+                    String userId = jwt.getSubject(); // sub
+                    String email = jwt.getClaimAsString("email");
+
+                    // TODO: role은 나중에 Keycloak 붙일 때 수정
+                    String role = "USER";
+
+                    ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+                            .header("X-User-Id", userId)
+                            .header("X-User-Email", email)
+                            .header("X-User-Role", role)
+                            .build();
+
+                    log.info("Injected Header -> userId: {}, email: {}", userId, email);
+
+                    return chain.filter(exchange.mutate().request(mutatedRequest).build());
+                })
+                .switchIfEmpty(chain.filter(exchange));
+    }
+}


### PR DESCRIPTION
## 🌱 설명

JwtHeaderFilter 구현

## 📌 관련 이슈

- close #3 

## ✅ 주요 변경 사항

- filter를 통해 userId, email, role header로 넘기기

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* API 게이트웨이에 JWT 기반 요청 헤더 주입 기능이 추가되었습니다. 인증된 사용자의 ID, 이메일, 역할 정보가 다운스트림 서비스로 헤더를 통해 전달되어 서비스 간 사용자 정보 공유가 원활합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->