### PR TITLE
[feature] enhance jwt processing user context propagation and rate limiting in gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ Authorization: Bearer {JWT_TOKEN}
 
 ### 📤 Gateway → 서비스 전달 헤더
 
-```http
-X-User-Id: {userId}
-X-User-Email: {email}
-X-User-Role: {role}
-```
+| 헤더 키      | 설명                         | 예시 값                                   |
+| ------------ | ---------------------------- | ----------------------------------------- |
+| X-User-Id    | 사용자의 UUID (Keycloak sub) | UUID 값                                   |
+| X-User-Email | 사용자의 이메일 주소         | test@test.com                             |
+| X-User-Role  | 사용자 권한                  | ADMIN or HUB_ADMIN or DELIVERY or COMPANY |
+
+#### 예시
 
 ---
 
@@ -64,22 +66,16 @@ X-User-Role: {role}
 ### 📌 Controller 예시
 
 ```java
-@RestController
-@RequestMapping("/api/v1/users")
-public class UserController {
-
-    @GetMapping("/me")
-    public ResponseEntity<?> getMyInfo(
-            @RequestHeader("X-User-Id") String userId,
-            @RequestHeader("X-User-Email") String email,
-            @RequestHeader("X-User-Role") String role
-    ) {
-        return ResponseEntity.ok(Map.of(
-                "userId", userId,
-                "email", email,
-                "role", role
-        ));
-    }
+@GetMapping("/api/v1/users/test")
+public String test(
+   @RequestHeader(value = "X-User-Id", required = false) String userId,
+   @RequestHeader(value = "X-User-Email", required = false) String email,
+   @RequestHeader(value = "X-User-Role", required = false) String role
+) {
+   if("ADMIN".equals(role)) {
+      return "userId=" + userId + ", email=" + email + ", role=" + role;
+   }
+   return "userId=" + userId + ", email=" + email;
 }
 ```
 
@@ -121,12 +117,85 @@ public class UserController {
 
 ---
 
-## 📈 기대 효과
+## 🛡️ 안정성 및 보안 설정
 
-- 인증 로직을 Gateway에 집중하여 **보안 강화**
-- 서비스 간 결합도 감소
-- 단일 진입점 제공으로 **확장성 향상**
-- 간단한 헤더 기반 사용자 정보 전달로 개발 생산성 향상
+### 1. Rate Limiting (요청 제한)
+
+- Redis를 사용하여 유저별/IP별 트래픽을 제어합니다.
+
+- 로그인 유저는 userId 기반, 비로그인 유저는 Remote IP 기반으로 키를 생성하여 무분별한 API 호출을 방지합니다.
+
+### 2. Circuit Breaker & Fallback
+
+- 특정 서비스 응답이 지연되거나 장애가 발생하면 즉시 Fallback 응답을 반환합니다.
+
+- 응답 규격 (503 Service Unavailable):
+
+```JSON
+{
+  "status": 503,
+  "service": "user-service",
+  "message": "다잇다 서비스가 일시적으로 지연되고 있습니다. 잠시 후 다시 시도해주세요.",
+  "timestamp": "2026-04-03T..."
+}
+```
+
+> ⚠️ Circuit Breaker (Resilience4j)를 사용하기 위해서는 각자 서비스에 등록해야합니다.
+
+## Circuit Breaker 등록 방법
+
+- **사용법**: 외부 호출이 발생하는 Service 메서드에 `@CircuitBreaker`를 붙이세요.
+- **Fallback**: 호출 실패 시 사용자에게 돌려줄 **기본 응답 로직**을 반드시 작성하세요.
+- **주의**: Fallback 메서드는 원본 메서드와 반환 타입이 같아야 하며, 마지막 파라미터로 `Throwable`을 받아야 합니다.
+
+### 1. 의존성 추가 (build.gradle)
+
+```gradle
+dependencies {
+   implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+   implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+   // 아직 infra-repo에는 prometheus가 없습니다. 추가하시고 주석처리 해주세요.
+   // docker에 올라가면 공지 하겠습니다!
+   runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+}
+```
+
+### 2. 로직에 적용 (Annotation 방식)
+
+각 서비스의 로직의 필요한 곳에 추가하시면 됩니다.
+아래는 예시이며 각자 비즈니스 로직에 맞게 사용하시면 됩니다.
+
+```java
+@Service
+@Slf4j
+public class OrderService {
+
+    // 1. Circuit Breaker 적용 (이름은 설정파일과 매칭)
+    // 2. fallbackMethod는 같은 클래스 내에 정의되어야 함
+    @CircuitBreaker(name = "orderService", fallbackMethod = "fallbackGetProductDetails")
+    public ProductResponse getProductDetails(Long productId) {
+
+        // 외부 서비스(Product Service) 호출 로직 (RestTemplate or FeignClient)
+        // 여기서 에러가 나거나 응답이 늦으면 Circuit이 열립니다.
+        return productClient.getProduct(productId);
+    }
+
+    // Fallback 메서드 (원본 메서드와 파라미터가 같아야 하며, Exception 객체가 추가됨)
+    public ProductResponse fallbackGetProductDetails(Long productId, Throwable t) {
+        log.error("Product service is down! Cause: {}", t.getMessage());
+
+        // 에러 발생 시 돌려줄 가짜(Mock) 데이터 혹은 기본값
+        return new ProductResponse(productId, "임시 상품 정보", 0L, "현재 정보를 불러올 수 없습니다.");
+    }
+}
+```
+
+### 3. 설정 파일 작성 (application.yml)
+
+`project-configs/configs/common` 에서 일괄적으로 관리하겠습니다.
+
+혹시 각 서비스마다 실패율이나 설정을 조정하고 싶다면 저에게 말씀해주세요.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ Authorization: Bearer {JWT_TOKEN}
 | X-User-Email | 사용자의 이메일 주소         | test@test.com                             |
 | X-User-Role  | 사용자 권한                  | ADMIN or HUB_ADMIN or DELIVERY or COMPANY |
 
-#### 예시
-
 ---
 
 ## 🧩 서비스에서 사용하는 방법

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/fhsh/gatewayserver/config/RateLimiterConfig.java
+++ b/src/main/java/com/fhsh/gatewayserver/config/RateLimiterConfig.java
@@ -1,0 +1,35 @@
+package com.fhsh.gatewayserver.config;
+
+import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.Principal;
+
+/**
+ * API 호출 횟수 제한(Rate Limiting)을 위한 키 식별 설정 클래스입니다.
+ * Redis 등과 연동하여 특정 시간 동안 허용할 요청 횟수를 관리할 때 사용됩니다.
+ */
+@Configuration
+public class RateLimiterConfig {
+
+    /**
+     * 사용자를 식별하는 '키(Key)'를 결정하는 Bean입니다.
+     * 1순위: 인증된 사용자의 ID (Username)
+     * 2순위: 인증되지 않은 경우 사용자의 IP 주소
+     */
+    @Bean
+    public KeyResolver userKeyResolver() {
+        return exchange ->
+                exchange.getPrincipal()
+                        .map(Principal::getName) // userId
+                        // 만약 로그인하지 않은 사용자라면
+                        .defaultIfEmpty(
+                                // 접속한 사용자의 IP 주소를 식별 키로 사용
+                                exchange.getRequest()
+                                        .getRemoteAddress()
+                                        .getAddress()
+                                        .getHostAddress()
+                        );
+    }
+}

--- a/src/main/java/com/fhsh/gatewayserver/config/SecurityConfig.java
+++ b/src/main/java/com/fhsh/gatewayserver/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyExchange().authenticated()
                 )
-//                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> {}))
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> {}))
                 .build();
     }
 }

--- a/src/main/java/com/fhsh/gatewayserver/filter/JwtHeaderFilter.java
+++ b/src/main/java/com/fhsh/gatewayserver/filter/JwtHeaderFilter.java
@@ -3,12 +3,16 @@ package com.fhsh.gatewayserver.filter;
 import org.springframework.core.Ordered;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * 전역 필터: 인증된 사용자의 JWT 토큰에서 정보를 추출하여
@@ -59,5 +63,21 @@ public class JwtHeaderFilter implements GlobalFilter, Ordered {
                     return chain.filter(exchange.mutate().request(mutatedRequest).build());
                 })
                 .switchIfEmpty(chain.filter(exchange));
+    }
+
+    /**
+     * JWT 내의 realm_access 클레임에서 권한(Roles) 리스트를 추출하는 헬퍼 메서드
+     * Keycloak의 표준 토큰 구조인 { "realm_access": { "roles": ["ADMIN", "USER"] } }를 파싱합니다.
+     */
+    private String extractSingleRole(Jwt jwt) {
+        Map<String, Object> realmAccess = jwt.getClaim("realm_access");
+        if (realmAccess != null && realmAccess.get("roles") instanceof Collection<?> roles) {
+            // 리스트의 첫 번째 요소를 가져오되, 없으면 빈 문자열
+            return roles.stream()
+                    .map(Object::toString)
+                    .findFirst()
+                    .orElse("");
+        }
+        return "";
     }
 }

--- a/src/main/java/com/fhsh/gatewayserver/filter/JwtHeaderFilter.java
+++ b/src/main/java/com/fhsh/gatewayserver/filter/JwtHeaderFilter.java
@@ -1,6 +1,6 @@
 package com.fhsh.gatewayserver.filter;
 
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -10,9 +10,25 @@ import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
-@Slf4j
+/**
+ * 전역 필터: 인증된 사용자의 JWT 토큰에서 정보를 추출하여
+ * 하위 서비스가 사용할 수 있도록 HTTP 헤더에 삽입합니다.
+ */
 @Component
-public class JwtHeaderFilter implements GlobalFilter {
+public class JwtHeaderFilter implements GlobalFilter, Ordered {
+
+    private static final String HEADER_USER_ID = "X-User-Id";
+    private static final String HEADER_USER_EMAIL = "X-User-Email";
+    private static final String HEADER_USER_ROLES = "X-User-Roles";
+
+    /**
+     * 필터 실행 순서 설정
+     * 보안 필터가 토큰을 검증한 후에 실행되어야 하므로 우선순위를 낮게(숫자를 크게) 설정
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE - 5;
+    }
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
@@ -39,8 +55,6 @@ public class JwtHeaderFilter implements GlobalFilter {
                             .header("X-User-Email", email)
                             .header("X-User-Role", role)
                             .build();
-
-                    log.info("Injected Header -> userId: {}, email: {}", userId, email);
 
                     return chain.filter(exchange.mutate().request(mutatedRequest).build());
                 })

--- a/src/main/java/com/fhsh/gatewayserver/filter/JwtHeaderFilter.java
+++ b/src/main/java/com/fhsh/gatewayserver/filter/JwtHeaderFilter.java
@@ -25,7 +25,7 @@ public class JwtHeaderFilter implements GlobalFilter, Ordered {
 
     private static final String HEADER_USER_ID = "X-User-Id";
     private static final String HEADER_USER_EMAIL = "X-User-Email";
-    private static final String HEADER_USER_ROLES = "X-User-Roles";
+    private static final String HEADER_USER_ROLE = "X-User-Role";
 
     /**
      * 필터 실행 순서 설정
@@ -60,7 +60,7 @@ public class JwtHeaderFilter implements GlobalFilter, Ordered {
                     ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
                             .header(HEADER_USER_ID, safe(userId))
                             .header(HEADER_USER_EMAIL, safe(email))
-                            .header(HEADER_USER_ROLES, role) // 단일 권한 그대로 삽입
+                            .header(HEADER_USER_ROLE, role) // 단일 권한 그대로 삽입
                             .build();
 
                     return chain.filter(exchange.mutate().request(mutatedRequest).build());
@@ -79,6 +79,8 @@ public class JwtHeaderFilter implements GlobalFilter, Ordered {
             // 리스트의 첫 번째 요소를 가져오되, 없으면 빈 문자열
             return roles.stream()
                     .map(Object::toString)
+                    // "default-"로 시작하는 기본 권한은 제외하고 필터링
+                    .filter(role -> !role.startsWith("default-roles") && !role.equals("offline_access") && !role.equals("uma_authorization"))
                     .findFirst()
                     .orElse("");
         }

--- a/src/main/java/com/fhsh/gatewayserver/filter/JwtHeaderFilter.java
+++ b/src/main/java/com/fhsh/gatewayserver/filter/JwtHeaderFilter.java
@@ -3,6 +3,8 @@ package com.fhsh.gatewayserver.filter;
 import org.springframework.core.Ordered;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.stereotype.Component;
@@ -37,10 +39,9 @@ public class JwtHeaderFilter implements GlobalFilter, Ordered {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 
-        return exchange.getPrincipal()
-                .cast(Authentication.class)
+        return ReactiveSecurityContextHolder.getContext()
+                .map(SecurityContext::getAuthentication)
                 .flatMap(auth -> {
-
                     // JWT 아닌 경우 그냥 통과
                     if (!(auth instanceof JwtAuthenticationToken jwtAuth)) {
                         return chain.filter(exchange);
@@ -48,21 +49,24 @@ public class JwtHeaderFilter implements GlobalFilter, Ordered {
 
                     var jwt = jwtAuth.getToken();
 
-                    String userId = jwt.getSubject(); // sub
+                    // 기본 정보 추출
+                    String userId = jwt.getSubject();
                     String email = jwt.getClaimAsString("email");
 
-                    // TODO: role은 나중에 Keycloak 붙일 때 수정
-                    String role = "USER";
+                    // 전역 권한(realm_access) 추출
+                    String role = extractSingleRole(jwt);
 
+                    // 헤더 추가하여 요청 변조
                     ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
-                            .header("X-User-Id", userId)
-                            .header("X-User-Email", email)
-                            .header("X-User-Role", role)
+                            .header(HEADER_USER_ID, safe(userId))
+                            .header(HEADER_USER_EMAIL, safe(email))
+                            .header(HEADER_USER_ROLES, role) // 단일 권한 그대로 삽입
                             .build();
 
                     return chain.filter(exchange.mutate().request(mutatedRequest).build());
                 })
-                .switchIfEmpty(chain.filter(exchange));
+                // 데이터가 없을 때
+                .switchIfEmpty(chain.filter(exchange)); // 인증 안 된 유저도 접근 가능한 API를 위해 필요
     }
 
     /**
@@ -79,5 +83,9 @@ public class JwtHeaderFilter implements GlobalFilter, Ordered {
                     .orElse("");
         }
         return "";
+    }
+
+    private String safe(String value) {
+        return value != null ? value : "";
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: gateway-service
+    name: gateway-server
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
@@ -11,7 +11,7 @@ spring:
         service-id: config-server
 
   config:
-    import: "configserver:"
+    import: "configserver:http://localhost:8888"
 
 management:
   endpoint:


### PR DESCRIPTION
## 🌱 설명

Keycloak 연동하여 Gateway server에서 인증 및 인가를 진행하며 각 서비스에게 사용자 정보를 헤더로 전달합니다.

## 📌 관련 이슈

- close #3  

## ✅ 주요 변경 사항

- [README.md](https://github.com/FiveHandSixHand/gateway-server/blob/6-feature-enhance-jwt-processing-user-context-propagation-and-rate-limiting-in-gateway/README.md) 를 참고해주세요

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

README.md 필독 하셔야합니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 ID 또는 IP 기반 Redis 연동 API 속도 제한(Rate Limiting) 추가
  * Circuit Breaker 및 Fallback 지원으로 장애 시 안정성 향상(503 JSON 응답 예시 포함)
  * 요청에서 JWT를 읽어 사용자 ID, 이메일, 역할을 자동으로 헤더로 전달

* **문서**
  * 게이트웨이 보안·안정성 설정 가이드 및 전송 헤더 예시 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->