### PR TITLE
[feature] add circuitbreaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ dependencies {
 }
 ```
 
-저는 위 예시처럼 github에서 의존성을 가져왔더니 안돼서 아래 의존성을 추가했습니다.
+혹시 위 예시처럼 github에서 의존성을 가져왔는데 에러가 발생한다면 아래 의존성을 추가해주세요.
 
 ```gradle
 implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
-runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+// runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 ```
 
 ### 2. 로직에 적용 (Annotation 방식)

--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ dependencies {
 }
 ```
 
+저는 위 예시처럼 github에서 의존성을 가져왔더니 안돼서 아래 의존성을 추가했습니다.
+
+```gradle
+implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
+runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+```
+
 ### 2. 로직에 적용 (Annotation 방식)
 
 각 서비스의 로직의 필요한 곳에 추가하시면 됩니다.

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/fhsh/gatewayserver/fallback/FallbackController.java
+++ b/src/main/java/com/fhsh/gatewayserver/fallback/FallbackController.java
@@ -1,0 +1,42 @@
+package com.fhsh.gatewayserver.fallback;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.cloud.gateway.route.Route;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/fallback")
+public class FallbackController {
+
+    /**
+     * 모든 서비스에서 공통으로 사용할 수 있는 통합 폴백 메서드입니다.
+     * 어떤 서비스에서 장애가 발생했는지 로그를 남기고 사용자에게 안내합니다.
+     */
+    @GetMapping("/common")
+    public ResponseEntity<Map<String, Object>> commonFallback(ServerWebExchange exchange) {
+        // 장애가 발생한 서비스의 Route 정보 추출
+        Route route = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+        String serviceName = (route != null) ? route.getId() : "Unknown Service";
+
+        log.error("Fallback 호출됨: 서비스 [{}]에 연결할 수 없거나 응답 시간이 초과되었습니다.", serviceName);
+
+        // 2. 응답 데이터 구성
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", HttpStatus.SERVICE_UNAVAILABLE.value());
+        response.put("error", "Service Unavailable");
+        response.put("message", String.format("[%s] 이용이 일시적으로 제한되었습니다. 잠시 후 다시 시도해주세요.", serviceName));
+        response.put("service", serviceName);
+
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(response);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,5 +15,12 @@ spring:
 
 management:
   endpoint:
+    web:
+      exposure:
+        include: health, resilience4j
     health:
       show-details: always
+
+logging:
+  level:
+    io.github.resilience4j: DEBUG


### PR DESCRIPTION
## 🌱 설명

 모든 서비스에서 공통으로 사용할 수 있는 통합 폴백 메서드를 작성했습니다. 

이는 gateway-server에서 수행하며 각 서비스의 circuitbreaker는 각자 적용하셔야 합니다.

어떤 서비스에서 장애가 발생했는지 로그를 남기고 사용자에게 안내하도록 추가했습니다.

## 📌 관련 이슈

- close #8 

## ✅ 주요 변경 사항

- resilience4j-circuitbreaker 의존성 추가 및 공통 설정(project-configs) 적용

- gateway-server 내 FallbackController 구현 (공통 폴백 로직)

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Spring Cloud Circuit Breaker(Resilience4j)를 통한 서비스 복원력 지원 추가
  * 서비스 오류 시 503 폴백 응답을 반환하는 공통 폴백 엔드포인트 제공
  * 헬스 체크 및 Resilience4j 모니터링 엔드포인트 활성화

* **문서**
  * Gradle 의존성 안내에 Circuit Breaker 추가 및 Prometheus 예시 주석 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->